### PR TITLE
Prevent remounting tunnel component on each render

### DIFF
--- a/src/TunnelPlaceholder.js
+++ b/src/TunnelPlaceholder.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { createElement, Component, Fragment } from 'react'
+import React, { Component, Fragment } from 'react'
 
 class TunnelPlaceholder extends Component {
   static propTypes = {
@@ -36,12 +36,12 @@ class TunnelPlaceholder extends Component {
     if (renderChildren) {
       if (Array.isArray(tunnelProps) || multiple) {
         return !tunnelProps
-          ? createElement(renderChildren, { items: [] })
-          : createElement(renderChildren, {
+          ? renderChildren({ items: [] })
+          : renderChildren({
               items: Array.isArray(tunnelProps) ? tunnelProps : [tunnelProps],
             })
       } else {
-        return createElement(renderChildren, tunnelProps || {})
+        return renderChildren(tunnelProps || {})
       }
     }
 


### PR DESCRIPTION
Currently, each time a tunnel is rendered, React will unmount and remount the entire component tree. This is not ideal when you have a stateful component like a text input. It will lose its state on each re-render, causing the input text to be reset, the cursor position to be lost, ect.

React remounts the tree each time because `createElement` is being called on the function child, resulting in a new element each time. The reconciler can't tell that these are not the same component with different props and re-renders the tree. To fix this, I changed the code to call the child function directly. This way the reconciler can diff against the returned elements from the function and see that they are the same, preventing a re-mount.