### PR TITLE
Change TunnelPlaceholder's component propType

### DIFF
--- a/src/TunnelPlaceholder.js
+++ b/src/TunnelPlaceholder.js
@@ -4,7 +4,7 @@ import React, { Component, Fragment } from 'react'
 class TunnelPlaceholder extends Component {
   static propTypes = {
     children: PropTypes.func,
-    component: PropTypes.func,
+    component: PropTypes.oneOfType([PropTypes.func, PropTypes.symbol]),
     id: PropTypes.string.isRequired,
     multiple: PropTypes.bool,
   }

--- a/src/TunnelPlaceholder.js
+++ b/src/TunnelPlaceholder.js
@@ -4,7 +4,7 @@ import React, { Component, Fragment } from 'react'
 class TunnelPlaceholder extends Component {
   static propTypes = {
     children: PropTypes.func,
-    component: PropTypes.oneOfType([PropTypes.node, PropTypes.symbol]),
+    component: PropTypes.func,
     id: PropTypes.string.isRequired,
     multiple: PropTypes.bool,
   }


### PR DESCRIPTION
As we pass a class constructor instead of an instance of a class, the right type is `func` (see for example react-router's component propType :  https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Route.js#L130)